### PR TITLE
Startup arguments for docker are broken (Incorrect parameters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cd annas-archive-api
 
 ```bash
 docker build -t annas-api .
-docker run -d --name annas-api -e 1337:8080 annas-api:latest
+docker run -d --name annas-api -p 1337:8080 annas-api:latest
 ```
 
 **On host:**


### PR DESCRIPTION
Incorrect docker port parameter, port supplied as a environment variable with -e instead of -p

Resulting in no port binding, hence the API being unaccessible.